### PR TITLE
Json delimiter issue#5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
-source 'https://rubygems.org'
-
-gem 'json', '>2.0'
+source 'https://rubygems.org' do
+  gem 'json', '>2.0'
+  gem 'yajl-ruby', require: 'yajl'
+end

--- a/func.rb
+++ b/func.rb
@@ -1,7 +1,8 @@
 require_relative 'lib/fdk'
 
 def myhandler(context, input)
-    STDERR.puts "call_id: " + context.call_id
+    STDERR.puts "call_id: #{context.call_id}"
+    STDERR.puts "input received: #{input}"
     name = "World"
     nin = input['name']
     if nin && nin != ""

--- a/func.yaml
+++ b/func.yaml
@@ -1,5 +1,5 @@
 name: examples
-version: 0.0.100
+version: 0.0.101
 runtime: ruby
 entrypoint: ruby func.rb
 format: json

--- a/func.yaml
+++ b/func.yaml
@@ -1,5 +1,5 @@
 name: examples
-version: 0.0.79
+version: 0.0.88
 runtime: ruby
 entrypoint: ruby func.rb
 format: json

--- a/func.yaml
+++ b/func.yaml
@@ -1,5 +1,5 @@
 name: examples
-version: 0.0.78
+version: 0.0.79
 runtime: ruby
 entrypoint: ruby func.rb
 format: json

--- a/func.yaml
+++ b/func.yaml
@@ -1,5 +1,5 @@
 name: examples
-version: 0.0.88
+version: 0.0.100
 runtime: ruby
 entrypoint: ruby func.rb
 format: json

--- a/lib/fdk/context.rb
+++ b/lib/fdk/context.rb
@@ -1,52 +1,49 @@
 module FDK
 
-    # Config looks up values in the env vars
-    class Config
-        def [](key)
-            return ENV[key.upcase]
-        end
+  # Config looks up values in the env vars
+  class Config
+    def [](key)
+      ENV[key.upcase]
+    end
+  end
+
+  class Context
+
+    # TODO: Rethink FN_PATH, if it's a reference to the route, maybe it should be FN_ROUTE? eg: if it's a dynamic path, this env var would
+    #    show the route's path (ie: route identifier), eg: /users/:name, not the actual path.
+
+    # FN_REQUEST_URL - the full URL for the request (parsing example)
+    # FN_APP_NAME - the name of the application that matched this route, eg: myapp
+    # FN_PATH - the matched route, eg: /hello
+    # FN_METHOD - the HTTP method for the request, eg: GET or POST
+    # FN_CALL_ID - a unique ID for each function execution.
+    # FN_FORMAT - a string representing one of the function formats, currently either default or http. Default is default.
+    # FN_MEMORY - a number representing the amount of memory available to the call, in MB
+    # FN_TYPE - the type for this call, currently 'sync' or 'async'
+    # FN_HEADER_$X - the HTTP headers that were set for this request. Replace $X with the upper cased name of the header and replace dashes in the header with underscores.
+    # $X - any configuration values you've set for the Application or the Route. Replace X with the upper cased name of the config variable you set. Ex: minio_secret=secret will be exposed via MINIO_SECRET env var.
+    # FN_PARAM_$Y
+
+    attr_reader :payload
+
+    def initialize(payload)
+      @payload = payload
     end
 
-    class Context
-
-        # TODO: Rethink FN_PATH, if it's a reference to the route, maybe it should be FN_ROUTE? eg: if it's a dynamic path, this env var would 
-        #    show the route's path (ie: route identifier), eg: /users/:name, not the actual path.
-
-        # FN_REQUEST_URL - the full URL for the request (parsing example)
-        # FN_APP_NAME - the name of the application that matched this route, eg: myapp
-        # FN_PATH - the matched route, eg: /hello
-        # FN_METHOD - the HTTP method for the request, eg: GET or POST
-        # FN_CALL_ID - a unique ID for each function execution.
-        # FN_FORMAT - a string representing one of the function formats, currently either default or http. Default is default.
-        # FN_MEMORY - a number representing the amount of memory available to the call, in MB
-        # FN_TYPE - the type for this call, currently 'sync' or 'async'
-        # FN_HEADER_$X - the HTTP headers that were set for this request. Replace $X with the upper cased name of the header and replace dashes in the header with underscores.
-        # $X - any configuration values you've set for the Application or the Route. Replace X with the upper cased name of the config variable you set. Ex: minio_secret=secret will be exposed via MINIO_SECRET env var.
-        # FN_PARAM_$Y
-
-        attr_reader :payload, :config
-
-        def initialize(payload)
-            @payload = payload
-        end
-
-        def config
-            return @config if @config
-            @config = Config.new
-            return @config
-        end
-
-        def call_id
-            payload['call_id']
-        end
-
-        def content_type
-            payload['content_type']
-        end
-
-        def protocol
-            payload['protocol']
-        end
-
+    def config
+      @config ||= Config.new
     end
+
+    def call_id
+      payload['call_id']
+    end
+
+    def content_type
+      payload['content_type']
+    end
+
+    def protocol
+      payload['protocol']
+    end
+  end
 end

--- a/lib/fdk/runner.rb
+++ b/lib/fdk/runner.rb
@@ -10,13 +10,13 @@ module FDK
     format = ENV['FN_FORMAT']
     if format == 'json'
       parser = Yajl::Parser.new
+
       parser.on_parse_complete = lambda do |payload|
         context = Context.new(payload)
         body = payload['body']
         if context.content_type == 'application/json' && body != ''
           body = Yajl::Parser.parse(body)
         end
-        STDERR.puts "body: #{body}"
         se = FDK.single_event(func, context, body)
         response = {
           headers: {
@@ -29,7 +29,9 @@ module FDK
         STDOUT.puts
         STDOUT.flush
       end
+
       STDIN.each_line { |line| parser.parse_chunk(line) }
+
     elsif format == 'default'
       body = STDIN.read
       payload = {}

--- a/lib/fdk/runner.rb
+++ b/lib/fdk/runner.rb
@@ -5,121 +5,51 @@
 require 'json'
 
 module FDK
-
-    def self.handle(func)
-        # STDERR.puts `env`
-        format = ENV['FN_FORMAT']
-        if format == "json"
-            obs = ""
-            first_bracket = false
-            # end_bracket=false
-            stack_count = 0
-            STDIN.each_char do |c|
-                # STDERR.puts "c: #{c}"
-                if c == '{'
-                    if !first_bracket
-                        # STDERR.puts "setting first_bracket"
-                        first_bracket = true
-                    end
-                    stack_count += 1
-                elsif c == '}'
-                    stack_count -= 1
-                end
-                if first_bracket
-                    # STDERR.puts "in first_bracket stack_count: #{stack_count}"
-                    obs += c
-                    if stack_count == 0 # found last bracket, so close this out
-                        # STDERR.puts "OBJECT: #{obs}"
-                        payload = JSON.parse(obs)
-                        # STDERR.puts "payload: #{payload.inspect}"
-                        ctx = Context.new(payload)
-                        # STDERR.puts "context: " + ctx.inspect
-                        # STDERR.flush
-                        body = payload['body']
-                        if ctx.content_type == 'application/json' && body != ""
-                            body = JSON.parse(body)
-                        end
-                        # TODO: begin/rescue so we can respond with proper error response and code
-                        se = FDK.single_event(func, ctx, body)
-                        response = {
-                            headers: {
-                                'Content-Type' => 'application/json'
-                            },
-                            'status_code' => 200,
-                            body: se.to_json,
-                        }
-                        STDOUT.puts response.to_json
-                        STDOUT.puts
-                        STDOUT.flush
-                        first_bracket = false
-                        obs = ""
-                    end
-                end
-            end
-
-            # STDIN.each do |line|
-            #     STDERR.puts "LINE: --#{line}--"
-            #     STDERR.flush
-            #     ls = line.strip
-            #     STDERR.puts "ls: #{ls}"
-            #     if ls == "}"
-            #         # STDERR.puts "endbracket true"
-            #         endbracket=true
-            #     elsif ls == "" && endbracket
-            #         # TODO: this isn't very robust, probably needs to be better :/
-            #         STDERR.puts "OBJECT: #{obs}"
-            #         payload = JSON.parse(obs)
-            #         STDERR.puts "payload: #{payload.inspect}"
-            #         c = Context.new(payload)
-            #         STDERR.puts "context: " + c.inspect
-            #         STDERR.flush
-            #         body = payload['body']
-            #         if c.content_type == 'application/json'
-            #             body = JSON.parse(body)
-            #         end
-            #         # TODO: begin/rescue so we can respond with proper error response and code
-            #         s = FDK.single_event(func, c, body)
-            #         response = {
-            #             headers: {
-            #                 'Content-Type' => 'application/json'
-            #             },
-            #             'status_code' => 200,
-            #             body: s.to_json,
-            #         }
-            #         STDOUT.puts response.to_json
-            #         STDOUT.puts
-            #         STDOUT.flush
-            #         obs = ""
-            #         next
-            #     else 
-            #         endbracket = false
-            #     end
-            #     obs += line
-            # end
-        elsif format == "default"
-            # TODO: check if content type json, and if so, parse it before passing it in
-            body = STDIN.read
-            payload = {}
-            payload['call_id'] = ENV['FN_CALL_ID']
-            payload['content_type'] = ENV['FN_HEADER_Content_Type']
-            payload['protocol'] = {
-                'type' => 'http',
-                'request_url' => ENV['FN_REQUEST_URL']
-            }
-            # STDERR.puts "payload: #{payload}"
-            c = Context.new(payload)
-            if c.content_type == "application/json"
-                # STDERR.puts "parsing json"
-                body = JSON.parse(body)
-            end
-            puts FDK.single_event(func, c, body).to_json
-        else
-            raise "Format '#{format}' not supported in Ruby FDK."
-        end
+  def self.handle(func)
+    format = ENV['FN_FORMAT']
+    if format == "json"
+      payload = JSON.parse(STDIN.read)
+      ctx = Context.new(payload)
+      body = payload['body']
+      if ctx.content_type == 'application/json' && body != ""
+        body = JSON.parse(body)
+      end
+      # TODO: begin/rescue so we can respond with proper error response and code
+      se = FDK.single_event(func, ctx, body)
+      response = {
+        headers: {
+          'Content-Type' => 'application/json',
+        },
+        'status_code' => 200,
+        body: se.to_json,
+      }
+      STDOUT.puts response.to_json
+      STDOUT.puts
+      STDOUT.flush
+    elsif format == "default"
+      # TODO: check if content type json, and if so, parse it before passing it in
+      body = STDIN.read
+      payload = {}
+      payload['call_id'] = ENV['FN_CALL_ID']
+      payload['content_type'] = ENV['FN_HEADER_Content_Type']
+      payload['protocol'] = {
+        'type' => 'http',
+        'request_url' => ENV['FN_REQUEST_URL'],
+      }
+      # STDERR.puts "payload: #{payload}"
+      c = Context.new(payload)
+      if c.content_type == "application/json"
+        # STDERR.puts "parsing json"
+        body = JSON.parse(body)
+      end
+      puts FDK.single_event(func, c, body).to_json
+    else
+      raise "Format '#{format}' not supported in Ruby FDK."
     end
+  end
 
-    def self.single_event(func, c, i)
-        s = send func, c, i
-        return s
-    end
+  def self.single_event(func, c, i)
+    s = send func, c, i
+    return s
+  end
 end

--- a/lib/fdk/runner.rb
+++ b/lib/fdk/runner.rb
@@ -11,22 +11,20 @@ module FDK
     if format == 'json'
       parser = Yajl::Parser.new
       parser.on_parse_complete = lambda do |payload|
-        STDERR.puts "payload: #{payload}"
         context = Context.new(payload)
         body = payload['body']
         if context.content_type == 'application/json' && body != ''
-          body = JSON.parse(body)
+          body = Yajl::Parser.parse(body)
         end
         STDERR.puts "body: #{body}"
         se = FDK.single_event(func, context, body)
         response = {
           headers: {
-            'Content-Type' => 'application/json',
+            'Content-Type' => 'application/json'
           },
           'status_code' => 200,
-          body: se.to_json,
+          body: se.to_json
         }
-        STDERR.puts "response: #{response}"
         STDOUT.puts response.to_json
         STDOUT.puts
         STDOUT.flush
@@ -39,10 +37,10 @@ module FDK
       payload['content_type'] = ENV['FN_HEADER_Content_Type']
       payload['protocol'] = {
         'type' => 'http',
-        'request_url' => ENV['FN_REQUEST_URL'],
+        'request_url' => ENV['FN_REQUEST_URL']
       }
       c = Context.new(payload)
-      body = JSON.parse(body) if c.content_type == 'application/json'
+      body = Yajl::Parser.parse(body) if c.content_type == 'application/json'
       puts FDK.single_event(func, c, body).to_json
     else
       raise "Format '#{format}' not supported in Ruby FDK."
@@ -50,7 +48,6 @@ module FDK
   end
 
   def self.single_event(func, context, input)
-    STDERR.puts "input sent: #{input}"
     send func, context, input
   end
 end

--- a/lib/fdk/runner.rb
+++ b/lib/fdk/runner.rb
@@ -7,49 +7,43 @@ require 'json'
 module FDK
   def self.handle(func)
     format = ENV['FN_FORMAT']
-    if format == "json"
+    if format == 'json'
       payload = JSON.parse(STDIN.read)
       ctx = Context.new(payload)
       body = payload['body']
-      if ctx.content_type == 'application/json' && body != ""
+      if ctx.content_type == 'application/json' && body != ''
         body = JSON.parse(body)
       end
       # TODO: begin/rescue so we can respond with proper error response and code
       se = FDK.single_event(func, ctx, body)
       response = {
         headers: {
-          'Content-Type' => 'application/json',
+          'Content-Type' => 'application/json'
         },
         'status_code' => 200,
-        body: se.to_json,
+        body: se.to_json
       }
       STDOUT.puts response.to_json
       STDOUT.puts
       STDOUT.flush
-    elsif format == "default"
-      # TODO: check if content type json, and if so, parse it before passing it in
+    elsif format == 'default'
       body = STDIN.read
       payload = {}
       payload['call_id'] = ENV['FN_CALL_ID']
       payload['content_type'] = ENV['FN_HEADER_Content_Type']
       payload['protocol'] = {
         'type' => 'http',
-        'request_url' => ENV['FN_REQUEST_URL'],
+        'request_url' => ENV['FN_REQUEST_URL']
       }
-      # STDERR.puts "payload: #{payload}"
       c = Context.new(payload)
-      if c.content_type == "application/json"
-        # STDERR.puts "parsing json"
-        body = JSON.parse(body)
-      end
+      body = JSON.parse(body) if c.content_type == 'application/json'
       puts FDK.single_event(func, c, body).to_json
     else
       raise "Format '#{format}' not supported in Ruby FDK."
     end
   end
 
-  def self.single_event(func, c, i)
-    s = send func, c, i
-    return s
+  def self.single_event(func, context, input)
+    send func, context, input
   end
 end

--- a/lib/fdk/version.rb
+++ b/lib/fdk/version.rb
@@ -1,5 +1,5 @@
 module FDK
 
-    VERSION = "0.0.8"
+    VERSION = "0.0.9"
 
 end

--- a/lib/fdk/version.rb
+++ b/lib/fdk/version.rb
@@ -1,5 +1,3 @@
 module FDK
-
-    VERSION = "0.0.9"
-
+  VERSION = "0.0.9"
 end

--- a/loop.rb
+++ b/loop.rb
@@ -1,5 +1,6 @@
 # assumes function deployed at least once
 puts `fn routes update myapp /fdk-ruby --format default`
+sleep 5
 puts "Cold"
 5.times do |i|
     start = Time.now
@@ -8,6 +9,7 @@ puts "Cold"
     puts
 end
 puts `fn routes update myapp /fdk-ruby --format json`
+sleep 5
 puts "Hot"
 5.times do |i|
     start = Time.now

--- a/loop.rb
+++ b/loop.rb
@@ -1,6 +1,6 @@
 # assumes function deployed at least once
 puts `fn routes update myapp /fdk-ruby --format default`
-# sleep 5
+sleep 1
 puts "Cold"
 5.times do |i|
     start = Time.now

--- a/loop.rb
+++ b/loop.rb
@@ -1,6 +1,6 @@
 # assumes function deployed at least once
 puts `fn routes update myapp /fdk-ruby --format default`
-sleep 5
+# sleep 5
 puts "Cold"
 5.times do |i|
     start = Time.now
@@ -9,7 +9,7 @@ puts "Cold"
     puts
 end
 puts `fn routes update myapp /fdk-ruby --format json`
-sleep 5
+sleep 1
 puts "Hot"
 5.times do |i|
     start = Time.now


### PR DESCRIPTION
Got nested braces working with the following test case:
```
{
  "name" : "Ghost Ship }",
  "details" : {
    "abv" : "4.5%",
    "type" : "Pale Ale",
    "url" : "http://adnams.co.uk/beer/our-beers/adnams-ghost-ship/"
  },
  "braces" : "{}",
  "left_brace" : "{",
  "right_brace" : "}"
}
```

Then ran RuboCop over it and fixed the minor offences.

Remaining issues:
- lack of module doc comment
- self.handle too long.

Created pull request here before starting on refactoring self.handle.