### PR TITLE
Pluggable IO streams for easier testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,12 @@ FDK.handle(myfunction)
 require 'fdk'
 
 def myfunction(context:, input:)
-    STDERR.puts "request_url: " + context.protocol['request_url']
-    STDERR.puts "call_id: " + context.call_id
-    STDERR.puts "input: " + input.to_s
-    { message: "Hello #{input['name']}!" }
+  input_value = input.respond_to?(:fetch) ? input.fetch('name') : input
+  name = input_value.to_s.strip.empty? ? 'World' : input_value
+  { message: "Hello #{name}!" }
 end
 
-FDK.handle(:myfunction)
+FDK.handle(function: :myfunction)
 ```
 
 ## Running the example that is in the root directory of this repo

--- a/func.rb
+++ b/func.rb
@@ -6,4 +6,4 @@ def myfunction(context:, input:)
   { message: "Hello #{name}!" }
 end
 
-FDK.handle(:myfunction)
+FDK.handle(function: :myfunction)

--- a/func.rb
+++ b/func.rb
@@ -1,9 +1,9 @@
 require_relative 'lib/fdk'
 
-def myfunction(context:, input:)
+def myfunction(context, input)
   input_value = input.respond_to?(:fetch) ? input.fetch('name') : input
   name = input_value.to_s.strip.empty? ? 'World' : input_value
   { message: "Hello #{name}!" }
 end
 
-FDK.handle(function: :myfunction)
+FDK.handle(:myfunction)

--- a/lib/fdk/runner.rb
+++ b/lib/fdk/runner.rb
@@ -6,7 +6,7 @@ require 'json'
 require 'yajl'
 
 module FDK
-  def self.handle(function:, input_stream: $stdin, output_stream: $stdout)
+  def self.handle(function)
     format = ENV['FN_FORMAT']
     if format == 'cloudevent'
       parser = Yajl::Parser.new
@@ -25,12 +25,12 @@ module FDK
           },
           'status_code' => 200
         }
-        output_stream.puts event.to_json
-        output_stream.puts
-        output_stream.flush
+        $stdout.puts event.to_json
+        $stdout.puts
+        $stdout.flush
       end
 
-      input_stream.each_line { |line| parser.parse_chunk(line) }
+      $stdin.each_line { |line| parser.parse_chunk(line) }
 
     elsif format == 'json'
       parser = Yajl::Parser.new
@@ -49,12 +49,12 @@ module FDK
           'status_code' => 200,
           body: se.to_json
         }
-        output_stream.puts response.to_json
-        output_stream.puts
-        output_stream.flush
+        $stdout.puts response.to_json
+        $stdout.puts
+        $stdout.flush
       end
 
-      input_stream.each_line { |line| parser.parse_chunk(line) }
+      $stdin.each_line { |line| parser.parse_chunk(line) }
 
     elsif format == 'default'
       event = {}
@@ -63,13 +63,13 @@ module FDK
         'type' => 'http',
         'request_url' => ENV['FN_REQUEST_URL']
       }
-      output_stream.puts FDK.single_event(function: function, context: Context.new(event), input: input_stream.read).to_json
+      $stdout.puts FDK.single_event(function: function, context: Context.new(event), input: $stdin.read).to_json
     else
       raise "Format '#{format}' not supported in Ruby FDK."
     end
   end
 
   def self.single_event(function:, context:, input:)
-    send function, context: context, input: input
+    send function, context, input
   end
 end

--- a/lib/fdk/runner.rb
+++ b/lib/fdk/runner.rb
@@ -6,7 +6,7 @@ require 'json'
 require 'yajl'
 
 module FDK
-  def self.handle(function)
+  def self.handle(function, input_stream: STDIN, output_stream: STDOUT)
     format = ENV['FN_FORMAT']
     if format == 'cloudevent'
       parser = Yajl::Parser.new
@@ -21,16 +21,16 @@ module FDK
         event['data'] = se
         event['extensions']['protocol'] = {
           headers: {
-              'Content-Type' => ['application/json']
+            'Content-Type' => ['application/json']
           },
           'status_code' => 200
         }
-        $stdout.puts event.to_json
-        $stdout.puts
-        $stdout.flush
+        output_stream.puts event.to_json
+        output_stream.puts
+        output_stream.flush
       end
 
-      $stdin.each_line { |line| parser.parse_chunk(line) }
+      input_stream.each_line { |line| parser.parse_chunk(line) }
 
     elsif format == 'json'
       parser = Yajl::Parser.new
@@ -49,12 +49,12 @@ module FDK
           'status_code' => 200,
           body: se.to_json
         }
-        $stdout.puts response.to_json
-        $stdout.puts
-        $stdout.flush
+        output_stream.puts response.to_json
+        output_stream.puts
+        output_stream.flush
       end
 
-      $stdin.each_line { |line| parser.parse_chunk(line) }
+      input_stream.each_line { |line| parser.parse_chunk(line) }
 
     elsif format == 'default'
       event = {}
@@ -63,7 +63,7 @@ module FDK
         'type' => 'http',
         'request_url' => ENV['FN_REQUEST_URL']
       }
-      $stdout.puts FDK.single_event(function: function, context: Context.new(event), input: $stdin.read).to_json
+      output_stream.puts FDK.single_event(function: function, context: Context.new(event), input: input_stream.read).to_json
     else
       raise "Format '#{format}' not supported in Ruby FDK."
     end

--- a/lib/fdk/runner.rb
+++ b/lib/fdk/runner.rb
@@ -15,7 +15,7 @@ module FDK
         context = Context.new(event)
         body = event['data']
         # Skipping json parsing of body because it would already be a parsed map according to the format spec defined here: https://github.com/cloudevents/spec/blob/master/serialization.md#json
-        se = FDK.single_event(function: func, context: context, input: body)
+        se = FDK.single_event(function: function, context: context, input: body)
 
         # Respond with modified event
         event['data'] = se
@@ -25,12 +25,12 @@ module FDK
           },
           'status_code' => 200
         }
-        STDOUT.puts event.to_json
-        STDOUT.puts
-        STDOUT.flush
+        output_stream.puts event.to_json
+        output_stream.puts
+        output_stream.flush
       end
 
-      STDIN.each_line { |line| parser.parse_chunk(line) }
+      input_stream.each_line { |line| parser.parse_chunk(line) }
 
     elsif format == 'json'
       parser = Yajl::Parser.new
@@ -70,6 +70,6 @@ module FDK
   end
 
   def self.single_event(function:, context:, input:)
-    send function, context, input
+    send function, context: context, input: input
   end
 end

--- a/lib/fdk/runner.rb
+++ b/lib/fdk/runner.rb
@@ -6,7 +6,7 @@ require 'json'
 require 'yajl'
 
 module FDK
-  def self.handle(function:, input_stream: STDIN, output_stream: STDOUT)
+  def self.handle(function:, input_stream: $stdin, output_stream: $stdout)
     format = ENV['FN_FORMAT']
     if format == 'cloudevent'
       parser = Yajl::Parser.new
@@ -23,7 +23,7 @@ module FDK
           headers: {
               'Content-Type' => ['application/json']
           },
-          'status_code' => 200,
+          'status_code' => 200
         }
         STDOUT.puts event.to_json
         STDOUT.puts
@@ -63,8 +63,7 @@ module FDK
         'type' => 'http',
         'request_url' => ENV['FN_REQUEST_URL']
       }
-      c = Context.new(event)
-      output_stream.puts FDK.single_event(function: function, context: c, input: input_stream.read).to_json
+      output_stream.puts FDK.single_event(function: function, context: Context.new(event), input: input_stream.read).to_json
     else
       raise "Format '#{format}' not supported in Ruby FDK."
     end


### PR DESCRIPTION
Added pluggable IO streams to `FDK.handle` (default to `STDIN`, `STDOUT`).

This is to make it easier to unit test the FDK outside of a container.

Also added named argument (`function:`) to `FDK.handle` and updated `func.rb` in README.md