### PR TITLE
fdk.12.rc1

### DIFF
--- a/fdk.gemspec
+++ b/fdk.gemspec
@@ -5,8 +5,8 @@ Gem::Specification.new do |s|
   s.name        = "fdk"
   s.version     = FDK::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Travis Reeder"]
-  s.email       = ["treeder@gmail.com"]
+  s.authors     = ["Travis Reeder", 'Ewan Slater']
+  s.email       = ["treeder@gmail.com", 'ewan.slater@gmail.com']
   s.homepage    = "https://github.com/fnproject/fdk-ruby"
   s.summary     = "Ruby FDK for Fn Project"
   s.description = "Ruby Function Developer Kit for Fn Project."
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.0"
 
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
+  s.add_runtime_dependency 'yajl-ruby', '~> 1.2', '>= 1.2.1'
 
   s.files = Dir['Rakefile', '{bin,lib,man,test,spec}/**/*', 'README*', 'LICENSE*'] & `git ls-files -z`.split("\0")
 end

--- a/lib/fdk/version.rb
+++ b/lib/fdk/version.rb
@@ -1,3 +1,3 @@
 module FDK
-  VERSION = "0.0.11"
+  VERSION = "0.0.12.rc1"
 end


### PR DESCRIPTION
Current gem release (0.0.11) is not consistent with the fdk-ruby repo.  Mainly because the FDK interface in the repo uses named parameters.

This PR creates a release candidate Gem with the interface updated.