### PR TITLE
Tidied default input.  Remove fn run from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,14 @@ With an fn server running (see
 `cd` to the [hello-ruby](examples/hello-ruby) folder and run:
 
 ```sh
-fn deploy --app examples --local && echo '{"name":"coolio"}' | fn invoke examples hello
+fn deploy --app examples --local
 ```
 
 The `--app examples` option tells fn to deploy the function as part of
 the _app_ named _examples_.
+
+The `--local` option tells fn not to push the function image to Docker
+Hub.
 
 ## Invoking functions
 Once we have deployed a function we can invoke it using `fn invoke`.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # Ruby Function Developer Kit (FDK)
-
 This provides a Ruby framework for developing functions for use with [Fn](https://fnproject.github.io).
 
 ## Function Handler
-
 To use this FDK, you simply need to require this gem.
 
 ```ruby
@@ -22,8 +20,8 @@ end
 * context - provides runtime information for your function, such as configuration values, headers, etc.
 * input – This parameter is a string containing body of the request.
 * output - is where you can return data back to the caller. Whatever you return will be sent back to the caller. If `async`, this value is ignored.
-  * Default output format should be in JSON, as Content-Type header will be `application/json` by default. You can be more flexible if you create and return
-    an FDK::Response object instead of a string.
+* Default output format should be in JSON, as Content-Type header will be `application/json` by default. You can be more flexible if you create and return
+an FDK::Response object instead of a string.
 
 Then simply pass that function to the FDK:
 
@@ -31,7 +29,13 @@ Then simply pass that function to the FDK:
 FDK.handle(:myfunction)
 ```
 
-## Hello World Example
+## Examples
+
+See the [examples](examples) folder of this repo for code examples.
+
+### Hello World Example
+
+In the [hello-ruby](examples/hello-ruby) folder there is a traditional "Hello  World" example.  The code is found in [func.rb](examples/hello-ruby/func.rb):
 
 ```ruby
 require 'fdk'
@@ -45,51 +49,45 @@ end
 FDK.handle(function: :myfunction)
 ```
 
-## Examples
+## Deploying functions
 
-See the [examples](examples) folder of this repo for code examples.
+To use a function we need to deploy it to an fn server.
 
-### Hello World
+In fn an _app_ consist of one or more functions and each function is
+deployed as part of an app.
 
-Running the [Hello World](examples/hello-ruby) example
-
-```sh
-$ echo '{"name":"coolio"}' | fn run
-{"message":"Hello coolio!"}
-```
-
-You can also specify the format (the default is JSON)
-
-```sh
-$ echo '{"name":"coolio"}' | fn run --format json
-{"message":"Hello coolio!"}
-```
-
-If you want to just pass plain text to the function, specify a format of __default__:
-
-```sh
-$ echo 'coolio' | fn run --format default
-{"message":"Hello coolio!"}
-```
-
-### Deploying the functions to an fn server
+We're going to deploy the hello world example as part of the app
+`examples`.
 
 With an fn server running (see
 [Quickstart](https://github.com/fnproject/fn/blob/master/README.md) if you need instructions):
 
-```sh
-fn deploy --app examples --local && echo '{"name":"coolio"}' | fn invoke examples hello
-```
-
-Change to hot:
-
-Update func.yaml: `format: json`
+`cd` to the [hello-ruby](examples/hello-ruby) folder and run:
 
 ```sh
 fn deploy --app examples --local && echo '{"name":"coolio"}' | fn invoke examples hello
 ```
 
-### Compare cold and hot functions
+The `--app examples` option tells fn to deploy the function as part of
+the _app_ named _examples_.
+
+## Invoking functions
+Once we have deployed a function we can invoke it using `fn invoke`.
+
+Running the [Hello World](examples/hello-ruby) example:
+```sh
+$ fn invoke examples hello
+{"message":"Hello World!"}
+```
+To get a more personal message, send a name in a JSON format and set the
+`content-type 'application/json'`:
+```
+echo '{"name":"Joe"}' | fn invoke examples hello --content-type
+'application/json'
+{"message":"Hello Joe!"}
+```
+
+## Compare cold and hot functions
 
 Run [loop.rb](examples/loop.rb)
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,7 @@ $ fn invoke examples hello
 To get a more personal message, send a name in a JSON format and set the
 `content-type 'application/json'`:
 ```
-echo '{"name":"Joe"}' | fn invoke examples hello --content-type
-'application/json'
+echo '{"name":"Joe"}' | fn invoke examples hello --content-type 'application/json'
 {"message":"Hello Joe!"}
 ```
 

--- a/examples/hello-ruby/Gemfile
+++ b/examples/hello-ruby/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org' do
   gem 'fdk','0.0.13.rc1'
-  # gem 'fdk','0.0.12'
 end

--- a/examples/hello-ruby/Gemfile
+++ b/examples/hello-ruby/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org' do
-  gem 'fdk','0.0.13.rc1'
+  gem 'fdk','~> 0.0.13'
 end

--- a/examples/hello-ruby/Gemfile
+++ b/examples/hello-ruby/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org' do
-  gem 'fdk','~> 0.0.12'
+  gem 'fdk','0.0.13.rc1'
+  # gem 'fdk','0.0.12'
 end

--- a/examples/hello-ruby/func.rb
+++ b/examples/hello-ruby/func.rb
@@ -1,6 +1,8 @@
 require 'fdk'
 
 def myfunction(context:, input:)
+  STDERR.puts("Hoot hoot")
+  STDERR.puts("format: " + ENV['FN_FORMAT'])
   input_value = input.respond_to?(:fetch) ? input.fetch('name') : input
   name = input_value.to_s.strip.empty? ? 'World' : input_value
   { message: "Hello #{name}!" }

--- a/examples/hello-ruby/func.rb
+++ b/examples/hello-ruby/func.rb
@@ -1,8 +1,6 @@
 require 'fdk'
 
 def myfunction(context:, input:)
-  STDERR.puts("Hoot hoot")
-  STDERR.puts("format: " + ENV['FN_FORMAT'])
   input_value = input.respond_to?(:fetch) ? input.fetch('name') : input
   name = input_value.to_s.strip.empty? ? 'World' : input_value
   { message: "Hello #{name}!" }

--- a/lib/fdk/runner.rb
+++ b/lib/fdk/runner.rb
@@ -63,7 +63,7 @@ module FDK
         'type' => 'http',
         'request_url' => ENV['FN_REQUEST_URL']
       }
-      output_stream.puts FDK.single_event(function: function, context: Context.new(event), input: input_stream.read).to_json
+      output_stream.puts FDK.single_event(function: function, context: Context.new(event), input: input_stream.read.chomp).to_json
     else
       raise "Format '#{format}' not supported in Ruby FDK."
     end

--- a/lib/fdk/version.rb
+++ b/lib/fdk/version.rb
@@ -1,3 +1,3 @@
 module FDK
-  VERSION = "0.0.13.rc1"
+  VERSION = "0.0.13"
 end

--- a/lib/fdk/version.rb
+++ b/lib/fdk/version.rb
@@ -1,3 +1,3 @@
 module FDK
-  VERSION = "0.0.12"
+  VERSION = "0.0.13.rc1"
 end


### PR DESCRIPTION
Added `chomp` to remove the trailing '\n' from default input.

Reworked README to replace deprecated `fn run` with `fn invoke`.  Dropped use of `--format` flag inherited from `fn run` by `fn invoke` (fixed yesterday by https://github.com/fnproject/cli/pull/419)