### PR TITLE
Writing the errors to STDERR (and hence the log) now

### DIFF
--- a/lib/fdk/call.rb
+++ b/lib/fdk/call.rb
@@ -36,6 +36,7 @@ module FDK
       format_response_body(fn_return: yield(context: context, input: input.parsed))
       good_response
     rescue StandardError => e
+      FDK.log_error(error: e)
       error_response(error: e)
     end
 

--- a/lib/fdk/listener.rb
+++ b/lib/fdk/listener.rb
@@ -38,8 +38,8 @@ module FDK
 
         handle_requests(socket: local_socket, fn_block: block)
       rescue StandardError => e
-        STDERR.puts "Error in request handling #{e}"
-        STDERR.puts e.backtrace
+        FDK.log(entry: "Error in request handling #{e}")
+        FDK.log(entry: e.backtrace)
       end
       local_socket.close
     end

--- a/lib/fdk/runner.rb
+++ b/lib/fdk/runner.rb
@@ -7,10 +7,27 @@ require "set"
 # Executes it with input
 # Responds with output
 module FDK
-  @dbg = ENV["FDK_DEBUG"]
+  FDK_LOG_THRESHOLD = "FDK_LOG_THRESHOLD".freeze
+  FDK_LOG_DEBUG = 0
+  FDK_LOG_DEFAULT = 1
+
+  def self.log_threshold
+    @log_threshold ||= ENV[FDK_LOG_THRESHOLD] ? ENV[FDK_LOG_THRESHOLD].to_i : FDK_LOG_DEFAULT
+  end
+
+  # Writes the entry to STDERR if the log_level >= log_threshold
+  # If no log level is specified, 1 is assumed.
+  def self.log(entry:, log_level: FDK_LOG_DEFAULT)
+    STDERR.puts(entry) if log_level >= log_threshold
+  end
+
+  def self.log_error(error:)
+    log(entry: error.message)
+    log(entry: error.backtrace.join("\n"), log_level: FDK_LOG_DEBUG)
+  end
 
   def self.debug(msg)
-    STDERR.puts(msg) if @dbg
+    log(entry: msg, log_level: FDK_LOG_DEBUG)
   end
 
   def self.handle(target:)

--- a/lib/fdk/version.rb
+++ b/lib/fdk/version.rb
@@ -1,3 +1,3 @@
 module FDK
-  VERSION = "0.0.15".freeze
+  VERSION = "0.0.16".freeze
 end


### PR DESCRIPTION
Errors were being returned to the caller as a JSON message, but not written to STDERR.

Have fixed that, so written to STDERR (and returned as JSON message).

Have replaced FDK_DEBUG with FDK_LOG_THRESHOLD so you can set different levels of logging.