### PR TITLE
Conn close

### DIFF
--- a/lib/fdk/listener.rb
+++ b/lib/fdk/listener.rb
@@ -51,6 +51,7 @@ module FDK
       req.parse(local_socket)
       FDK.debug "got request #{req}"
       fn_block.call(req, resp)
+      resp["Connection"] = "close" # we're not using keep alives sadly
       resp.send_response(local_socket)
       FDK.debug "sending resp  #{resp.status}, #{resp.header}"
       local_socket.close

--- a/lib/fdk/runner.rb
+++ b/lib/fdk/runner.rb
@@ -18,7 +18,7 @@ module FDK
   # Writes the entry to STDERR if the log_level >= log_threshold
   # If no log level is specified, 1 is assumed.
   def self.log(entry:, log_level: FDK_LOG_DEFAULT)
-    STDERR.puts(entry) if log_level >= log_threshold
+    warn(entry) if log_level >= log_threshold
   end
 
   def self.log_error(error:)


### PR DESCRIPTION
closes #26 

we're using a socket and closing it each request, so we should send this header that we've done so until we can add support for keep alives here. 