### PR TITLE
If enabled, print log framing content to stdout/stderr

### DIFF
--- a/examples/hello-ruby/Gemfile
+++ b/examples/hello-ruby/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org' do
-  gem 'fdk','>= 0.0.19'
+  gem 'fdk','>= 0.0.20'
 end

--- a/lib/fdk.rb
+++ b/lib/fdk.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "fdk/version"
 require_relative "fdk/runner"
 require_relative "fdk/context"

--- a/lib/fdk/call.rb
+++ b/lib/fdk/call.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FDK
   # Call represents a call to the target function or lambda
   class Call

--- a/lib/fdk/context.rb
+++ b/lib/fdk/context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "date"
 
 module FDK

--- a/lib/fdk/function.rb
+++ b/lib/fdk/function.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FDK
   # Function represents a function function or lambda
   class Function

--- a/lib/fdk/listener.rb
+++ b/lib/fdk/listener.rb
@@ -85,7 +85,9 @@ module FDK
 
       frm = "\n#{@fn_logframe_name}=#{v[0]}\n"
       $stderr.print frm
+      $stderr.flush
       $stdout.print frm
+      $stdout.flush
     end
 
     def logframe_vars_exist

--- a/lib/fdk/listener.rb
+++ b/lib/fdk/listener.rb
@@ -77,15 +77,22 @@ module FDK
     end
 
     def log_frame_header(headers)
-      return if @fn_logframe_name.nil? || @fn_logframe_hdr.nil?
+      return unless logframe_vars_exist
 
       k = @fn_logframe_hdr.downcase
       v = headers[k]
-      return if v.nil?
+      return if v.nil? || v.empty?
 
       frm = "\n#{@fn_logframe_name}=#{v[0]}\n"
       $stderr.print frm
       $stdout.print frm
+    end
+
+    def logframe_vars_exist
+      return false if @fn_logframe_name.nil? || @fn_logframe_name.empty? ||
+                      @fn_logframe_hdr.nil? || @fn_logframe_hdr.empty?
+
+      true
     end
   end
 end

--- a/lib/fdk/runner.rb
+++ b/lib/fdk/runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "webrick"
 require "fileutils"
 require "json"
@@ -7,7 +9,7 @@ require "set"
 # Executes it with input
 # Responds with output
 module FDK
-  FDK_LOG_THRESHOLD = "FDK_LOG_THRESHOLD".freeze
+  FDK_LOG_THRESHOLD = "FDK_LOG_THRESHOLD"
   FDK_LOG_DEBUG = 0
   FDK_LOG_DEFAULT = 1
 

--- a/lib/fdk/support_classes.rb
+++ b/lib/fdk/support_classes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FDK
   # ParsedInput stores raw input and can parse it as
   # JSON (add extra formats as required)

--- a/lib/fdk/version.rb
+++ b/lib/fdk/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FDK
-  VERSION = "0.0.19".freeze
+  VERSION = "0.0.19"
 end

--- a/lib/fdk/version.rb
+++ b/lib/fdk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FDK
-  VERSION = "0.0.19"
+  VERSION = "0.0.20"
 end


### PR DESCRIPTION
Helps stdout/stderr parsers associate a request ID with a sequence of logs