### PR TITLE
Releasing version 0.0.26

### DIFF
--- a/lib/fdk/context.rb
+++ b/lib/fdk/context.rb
@@ -51,6 +51,8 @@ module FDK
   # Represents outbound HTTP headers
   class OutHeaders < InHeaders
     def initialize(headers, key_in_fn)
+      headers["Fn-Fdk-Version"] = ["fdk-ruby/#{FDK::VERSION}"]
+      headers["Fn-Fdk-Runtime"] = ["ruby/#{RUBY_VERSION}"]
       super(headers, key_in_fn)
     end
 

--- a/lib/fdk/version.rb
+++ b/lib/fdk/version.rb
@@ -17,5 +17,5 @@
 #
 
 module FDK
-  VERSION = "0.0.25"
+  VERSION = "0.0.26"
 end

--- a/tests/test_fdk.rb
+++ b/tests/test_fdk.rb
@@ -66,6 +66,8 @@ class TestFdk < Test::Unit::TestCase
       assert_equal 200, resp.code.to_i
       assert_equal "\"hello world\"", resp.body
       assert_equal "application/json", resp["content-type"]
+      assert_equal "fdk-ruby/#{FDK::VERSION}", resp["fn-fdk-version"]
+      assert_equal "ruby/#{RUBY_VERSION}", resp["fn-fdk-runtime"]
     }
   end
 


### PR DESCRIPTION
Started tracking Ruby runtime version in Fn-Fdk-Runtime header in ruby/x.y.z format.